### PR TITLE
[dicp][ascend] feat: support aot_operation in graph compilation

### DIFF
--- a/dicp/dicp/dynamo_bridge/compile_fx.py
+++ b/dicp/dicp/dynamo_bridge/compile_fx.py
@@ -82,6 +82,7 @@ def compile_fx_inner(
     gt = GraphTransformer(gm, backend)
     gt.transform()
     gt.infer_shape_dtype()
+    gt.partition_graph_with_aot_op()
     compiled_fn = gt.compile_to_fn()
 
     # aot autograd needs to know to pass in inputs as a list

--- a/dicp/dicp/vendor/AscendGraph/codegen/graph_utils.h
+++ b/dicp/dicp/vendor/AscendGraph/codegen/graph_utils.h
@@ -152,7 +152,7 @@ ge::DataType get_ascend_datatype(const std::string& data_type) {
   if (datatype_map.count(data_type) > 0) {
     return datatype_map[data_type];
   }
-  throw std::runtime_error("invalid ascend data type!");
+  throw std::runtime_error("invalid ascend data type: " + data_type);
 }
 
 template <typename T>

--- a/dicp/dicp/vendor/AscendGraph/config.py
+++ b/dicp/dicp/vendor/AscendGraph/config.py
@@ -12,3 +12,9 @@ def get_decomp():
 
 
 decomp = get_decomp()
+
+enable_aot_operations = False
+aot_operations_prefix = "dicp.vendor.AscendGraph.ascend_op."
+aot_operations = {
+    "DIOPIRMSNorm": None,
+}


### PR DESCRIPTION
本PR主要功能是提供了一套在 dicp 图编译流程中，能够对于 diopi 算子进行在 python 层面调用的方案，主要是实现方式在图编译过程中针对特定的 pattern 进行匹配并替换为输入输出适配 diopi 的 ascend_op，然后根据相应的 op 在后端进行切图，满足 diopi 对应的 ascend_op 不入图，其余算子入图进行编译。单个图编译器流程被切分为若干个小子图的编译和 diopi 对应 ascend_op 的代码生成。本功能的开启通过 `dicp.vendor.AscendGraph.config.enable_aot_operations = True` 开启，默认状态为关闭。

主要的修改如下：
1. 在 pattern_replacement.py 中增加了 ascendgraph 的新 pattern：aten ir 层面的 rms_norm 若干op子图替换为 ascenr ir 层面的 DIOPIRMSNorm op。
2. 在 graph.py 的 GraphTransformer 中添加 partition_graph_with_aot_op，运行该函数后会将除了 DIOPIRMSNorm 以外的 ascend op 分为若干个小的子图，在 GraphModule 中以 call_module 的语句进行调用。
3. ascend codegen 重构，调整了部分 codegen 的执行顺序并抽象了新的函数形成 codegen base类，并在继承调整后的 codegen base 类后的 codegen 中进行若干 submodule graph 的编译和 aot 算子（如 DIOPIRMSNorm）的代码生成。这些逻辑的改动最终会反映在生成的图执行 python 文件内。

**重点：该功能为 dicp ascendgraph 相关的 breaking change 功能，可能会影响到动态形状编译的相关运行**

暂无测例，目前 diopiRMSNorm 尚未适配 pytorch 2.1 ，在 dicp 中无法执行。